### PR TITLE
Force definition of infile

### DIFF
--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -22,12 +22,11 @@ class OntologyNetwork:
     Network representation of Onto
     """
 
-    def __init__(self, infile=None):
-        if infile is not None:
-            self.g = nx.DiGraph()
-            self.onto = OntoParser(infile)
-            self.terms = AttrSetter()
-            self._parse_all()
+    def __init__(self, infile):
+        self.g = nx.DiGraph()
+        self.onto = OntoParser(infile)
+        self.terms = AttrSetter()
+        self._parse_all()
 
     
     def _assign_attributes(self):


### PR DESCRIPTION
It has to be either the one that I pushed, or at least `self.g`, `self.onto` and `self.terms` must be defined even if `infile` is not given