### PR TITLE
[patch] Define data dict to facilitate __add__

### DIFF
--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -3,7 +3,7 @@ import graphviz
 import pandas as pd
 
 from tools4rdf.network.attrsetter import AttrSetter
-from tools4rdf.network.parser import read_ontology
+from tools4rdf.network.parser import read_ontology, OntoParser
 from tools4rdf.network.term import OntoTerm
 
 


### PR DESCRIPTION
Following [my comment here](https://github.com/OCDO/tools4RDF/issues/3#issuecomment-2735550467), I suggest to leverage the `__add__` function of `rdflib.Graph`, so that we do not need to update the data, but parse the combined graph. It makes `__add__` particularly clean.