### PR TITLE
Make `OntoTerm` safer

### DIFF
--- a/tools4rdf/network/parser.py
+++ b/tools4rdf/network/parser.py
@@ -244,8 +244,11 @@ class OntoParser:
 
     def create_term(self, cls):
         iri = cls.toPython()
-        term = OntoTerm(iri, namespace=self._lookup_namespace(iri))
-        term.description = self.get_description(cls)
+        term = OntoTerm(
+            uri=iri,
+            namespace=self._lookup_namespace(iri),
+            description=self.get_description(cls),
+        )
         term._object = cls
         return term
 

--- a/tools4rdf/network/parser.py
+++ b/tools4rdf/network/parser.py
@@ -248,8 +248,8 @@ class OntoParser:
             uri=iri,
             namespace=self._lookup_namespace(iri),
             description=self.get_description(cls),
+            target=cls,
         )
-        term._object = cls
         return term
 
     def _lookup_namespace(self, uri):
@@ -269,14 +269,14 @@ class OntoParser:
 
     def parse_subclasses(self):
         for key, cls in self.attributes["class"].items():
-            for obj in self.graph.objects(cls._object, RDFS.subClassOf):
+            for obj in self.graph.objects(cls.target, RDFS.subClassOf):
                 superclasses = self.lookup_class(obj)
                 for superclass in superclasses:
                     self.attributes["class"][superclass].subclasses.append(cls.name)
 
     def parse_equivalents(self):
         for key, cls in self.attributes["class"].items():
-            for equivalent in self.graph.objects(cls._object, OWL.equivalentClass):
+            for equivalent in self.graph.objects(cls.target, OWL.equivalentClass):
                 if strip_name(equivalent) in self.attributes["class"]:
                     self.attributes["class"][
                         strip_name(equivalent)

--- a/tools4rdf/network/term.py
+++ b/tools4rdf/network/term.py
@@ -66,6 +66,7 @@ class OntoTerm:
         delimiter="/",
         description=None,
         label=None,
+        target=None,
     ):
 
         self.uri = uri
@@ -102,7 +103,7 @@ class OntoTerm:
         # condition parents are the parents that have conditions
         # these are accumulated when using the & or || operators
         self._condition_parents = []
-        self._object = None
+        self.target = target
 
     @property
     def URIRef(self):


### PR DESCRIPTION
There are functionalities defined in `OntoTerm` which may or may not be available depending on the definition, but some error messages are not necessarily helpful. I'm trying to achieve:

1. Put all definitions into `__init__`
2. Not access private attributes from outside