### PR TITLE
Separate onto reader

### DIFF
--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -25,7 +25,6 @@ class OntologyNetworkBase:
         self.terms._add_attribute(self.onto.get_attributes())
 
     def __add__(self, ontonetwork):
-        # add onto network
         onto = self.onto + ontonetwork.onto
         return OntologyNetworkBase(onto)
 

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -26,8 +26,7 @@ class OntologyNetworkBase:
 
     def __add__(self, ontonetwork):
         onto = self.onto + ontonetwork.onto
-        return OntologyNetworkBase(onto)
-
+        return self.__class__(onto)
     def strip_name(self, name):
         raw = name.split(":")
         if len(raw) > 1:

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -26,11 +26,8 @@ class OntologyNetworkBase:
 
     def __add__(self, ontonetwork):
         # add onto network
-        self.onto = self.onto + ontonetwork.onto
-        # now parse again
-        self.g = self.onto.get_networkx_graph()
-        self._assign_attributes()
-        return self
+        onto = self.onto + ontonetwork.onto
+        return OntologyNetworkBase(onto)
 
     def strip_name(self, name):
         raw = name.split(":")

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -26,7 +26,7 @@ class OntologyNetworkBase:
 
     def __add__(self, ontonetwork):
         onto = self.onto + ontonetwork.onto
-        return self.__class__(onto)
+        return OntologyNetworkBase(onto)
     def strip_name(self, name):
         raw = name.split(":")
         if len(raw) > 1:

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -10,13 +10,13 @@ def _replace_name(name):
     return ".".join(name.split(":"))
 
 
-class OntologyNetwork:
+class OntologyNetworkBase:
     """
     Network representation of Onto
     """
 
-    def __init__(self, infile):
-        self.onto = parse_ontology(infile)
+    def __init__(self, onto):
+        self.onto = onto
         self.terms = AttrSetter()
         self.g = self.onto.get_networkx_graph()
         self._assign_attributes()
@@ -370,3 +370,12 @@ class OntologyNetwork:
                 return pd.DataFrame(res, columns=labels)
 
         return res
+
+
+class OntologyNetwork(OntologyNetworkBase):
+    """
+    Network representation of Onto
+    """
+
+    def __init__(self, infile):
+        super().__init__(parse_ontology(infile))


### PR DESCRIPTION
Separate `OntologyNetworkBase` from `OntologyNetwork` so that `__add__` does not change the content of the original classes, i.e. currently `A = B + C` changes the content of `B`, but this should not happen.