### PR TITLE
remove explicit file check so IRIs can be parsed

### DIFF
--- a/tools4rdf/network/parser.py
+++ b/tools4rdf/network/parser.py
@@ -7,8 +7,6 @@ from rdflib import Graph, RDF, RDFS, OWL, BNode, URIRef
 
 
 def parse_ontology(infile, format="xml"):
-    if not os.path.exists(infile):
-        raise FileNotFoundError(f"file {infile} not found!")
     graph = Graph()
     graph.parse(infile, format=format)
     return OntoParser(graph)


### PR DESCRIPTION
This pull request includes a change to the `tools4rdf/network/parser.py` file to improve the robustness of the `parse_ontology` function by removing an unnecessary file existence check.

Codebase simplification:

* [`tools4rdf/network/parser.py`](diffhunk://#diff-64e602b978869249cd960cb3ea0cbcc3aacdacf3a37f5f008599cf7c65f6a5b9L10-L11): Removed the check for file existence (`os.path.exists(infile)`) and the corresponding `FileNotFoundError` exception to streamline the `parse_ontology` function.

closes #38 