### PR TITLE
Fix extra namespaces

### DIFF
--- a/tools4rdf/network/parser.py
+++ b/tools4rdf/network/parser.py
@@ -351,7 +351,12 @@ class OntoParser:
 
     def get_attributes(self):
         # add first level - namespaces
-        mapdict = {key: {} for key in self.namespaces.keys()}
+        namespaces = []
+        for k1 in ["class", "object_property", "data_property"]:
+            for k2, val in self.attributes[k1].items():
+                if val.namespace not in namespaces:
+                    namespaces.append(val.namespace)
+        mapdict = {key: {} for key in namespaces.keys()}
 
         # now iterate over all attributes
         for k1 in ["class", "object_property", "data_property"]:

--- a/tools4rdf/network/parser.py
+++ b/tools4rdf/network/parser.py
@@ -356,7 +356,7 @@ class OntoParser:
             for k2, val in self.attributes[k1].items():
                 if val.namespace not in namespaces:
                     namespaces.append(val.namespace)
-        mapdict = {key: {} for key in namespaces.keys()}
+        mapdict = {key: {} for key in namespaces}
 
         # now iterate over all attributes
         for k1 in ["class", "object_property", "data_property"]:


### PR DESCRIPTION
This pull request includes changes to the `tools4rdf/network/parser.py` file to improve the handling of namespaces in the `get_attributes` method. The most important change is the modification of the `mapdict` initialization to dynamically collect namespaces from the attributes instead of using the predefined `self.namespaces`.

Improvements to namespace handling:

* [`tools4rdf/network/parser.py`](diffhunk://#diff-64e602b978869249cd960cb3ea0cbcc3aacdacf3a37f5f008599cf7c65f6a5b9L354-R359): Modified the `get_attributes` method to dynamically collect namespaces from the attributes (`class`, `object_property`, `data_property`) and initialize `mapdict` with these namespaces. This ensures that only relevant namespaces are included in the dictionary.