### PR TITLE
Change how predicate behaves

### DIFF
--- a/examples/01_sparql_queries.ipynb
+++ b/examples/01_sparql_queries.ipynb
@@ -678,9 +678,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pyiron",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "pyiron"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -692,7 +692,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/examples/pizza.ipynb
+++ b/examples/pizza.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 1,
    "id": "fe5391cd-0816-4b81-b491-9439b642b0dd",
    "metadata": {},
    "outputs": [],
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 2,
    "id": "cbab587f-a127-4436-81ce-3e625a9ba7bd",
    "metadata": {},
    "outputs": [],
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 3,
    "id": "39282722-fadf-4b9f-ae66-08ccdf75769d",
    "metadata": {},
    "outputs": [],
@@ -36,18 +36,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 4,
    "id": "f792eaa2-90f3-410e-a68d-70f212e71d59",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "pizza:hasTopping\n",
-       "Note that hasTopping is inverse functional because isToppingOf is functional"
+       "pizza:hasSpiciness"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -58,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 5,
    "id": "6e51475a-3a39-4247-91f4-93bbb117d170",
    "metadata": {},
    "outputs": [],
@@ -68,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 6,
    "id": "58313894-d0c7-451f-82e4-a0efc6dcec00",
    "metadata": {},
    "outputs": [
@@ -303,7 +302,7 @@
        "8                    115     -  11.50         -  "
       ]
      },
-     "execution_count": 46,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -314,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 9,
    "id": "33809ed9-73e1-4660-bfb4-f8c538cd1403",
    "metadata": {},
    "outputs": [],
@@ -325,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 10,
    "id": "a07b7f0b-4d07-4b47-89c4-e36e0a2e9bf0",
    "metadata": {},
    "outputs": [],
@@ -341,9 +340,9 @@
     "    pizzabase = str(row[\"PIZZABASE\"])\n",
     "    if pizzabase != \"-\":\n",
     "        if pizzabase in termdict.keys():\n",
-    "            baseid = termdict['pizzabase']\n",
+    "            baseid = termdict[pizzabase]\n",
     "        else:\n",
-    "            baseid = get_id(pizzabase)\n",
+    "            baseid = URIRef(get_id(pizzabase))\n",
     "            termdict[pizzabase] = baseid\n",
     "            g.add((baseid, RDF.type, getattr(nm, pizzabase)))\n",
     "        \n",
@@ -356,8 +355,13 @@
     "    for (topping, calorie) in zip(toppings, calories):\n",
     "        topbase = str(row[topping])\n",
     "        if topbase != \"-\":\n",
-    "            \n",
-    "            g.add((term, nm.hasTopping, getattr(nm, topbase)))  \n",
+    "            if topbase in termdict.keys():\n",
+    "                topid = termdict[topbase]\n",
+    "            else:\n",
+    "                topid = URIRef(get_id(topbase))\n",
+    "                termdict[topbase] = topid\n",
+    "                g.add((topid, RDF.type, getattr(nm, topbase)))\n",
+    "            g.add((term, nm.hasTopping, topid)) \n",
     "        \n",
     "        calbase = str(row[calorie])\n",
     "        if calbase != \"-\":\n",
@@ -366,7 +370,13 @@
     "    #add base\n",
     "    food = str(row[\"FOOD\"])\n",
     "    if food != \"-\":\n",
-    "        g.add((term, nm.hasIngredient, getattr(nm, food)))\n",
+    "        if food in termdict.keys():\n",
+    "            foodid = termdict[food]\n",
+    "        else:\n",
+    "            foodid = URIRef(get_id(food))\n",
+    "            termdict[food] = foodid\n",
+    "            g.add((foodid, RDF.type, getattr(nm, food)))\n",
+    "        g.add((term, nm.hasIngredient, foodid))\n",
     "\n",
     "    #add base\n",
     "    price = str(row[\"PRICE\"])\n",
@@ -376,99 +386,34 @@
     "    #add base\n",
     "    spice = str(row[\"SPICINESS\"])\n",
     "    if spice != \"-\":\n",
-    "        g.add((term, nm.hasSpiciness, getattr(nm, spice)))"
+    "        if spice in termdict.keys():\n",
+    "            spiceid = termdict[spice]\n",
+    "        else:\n",
+    "            spiceid = URIRef(get_id(spice))\n",
+    "            termdict[spice] = spiceid\n",
+    "            g.add((spiceid, RDF.type, getattr(nm, spice)))\n",
+    "        g.add((term, nm.hasSpiciness, spiceid))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 11,
    "id": "ec496e8e-20f6-42c2-bdbc-d2d2dbb58712",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=N98c82271415740269863148d9e78b94a (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=Nbd2929ffbb1547e1b3cc15ab66477a4a (<class 'rdflib.graph.Graph'>)>"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "g.serialize(\"pizza_kg.ttl\", format=\"turtle\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 66,
-   "id": "13a31b25-6adc-4b77-aeb2-9eeb1dbbeb0e",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'brick': 'https://brickschema.org/schema/Brick#',\n",
-       " 'csvw': 'http://www.w3.org/ns/csvw#',\n",
-       " 'dc': 'http://purl.org/dc/elements/1.1/',\n",
-       " 'dcat': 'http://www.w3.org/ns/dcat#',\n",
-       " 'dcmitype': 'http://purl.org/dc/dcmitype/',\n",
-       " 'dcterms': 'http://purl.org/dc/terms/',\n",
-       " 'dcam': 'http://purl.org/dc/dcam/',\n",
-       " 'doap': 'http://usefulinc.com/ns/doap#',\n",
-       " 'foaf': 'http://xmlns.com/foaf/0.1/',\n",
-       " 'geo': 'http://www.opengis.net/ont/geosparql#',\n",
-       " 'odrl': 'http://www.w3.org/ns/odrl/2/',\n",
-       " 'org': 'http://www.w3.org/ns/org#',\n",
-       " 'prof': 'http://www.w3.org/ns/dx/prof/',\n",
-       " 'prov': 'http://www.w3.org/ns/prov#',\n",
-       " 'qb': 'http://purl.org/linked-data/cube#',\n",
-       " 'schema': 'https://schema.org/',\n",
-       " 'sh': 'http://www.w3.org/ns/shacl#',\n",
-       " 'skos': 'http://www.w3.org/2004/02/skos/core#',\n",
-       " 'sosa': 'http://www.w3.org/ns/sosa/',\n",
-       " 'ssn': 'http://www.w3.org/ns/ssn/',\n",
-       " 'time': 'http://www.w3.org/2006/time#',\n",
-       " 'vann': 'http://purl.org/vocab/vann/',\n",
-       " 'void': 'http://rdfs.org/ns/void#',\n",
-       " 'wgs': 'https://www.w3.org/2003/01/geo/wgs84_pos#',\n",
-       " 'owl': 'http://www.w3.org/2002/07/owl#',\n",
-       " 'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',\n",
-       " 'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',\n",
-       " 'xsd': 'http://www.w3.org/2001/XMLSchema#',\n",
-       " 'xml': 'http://www.w3.org/XML/1998/namespace',\n",
-       " 'pizza': 'https://example.org/pizza'}"
-      ]
-     },
-     "execution_count": 66,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "onto.namespaces"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 67,
-   "id": "983e499f-4f46-4e99-a5c5-d3daa0a93a97",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'https://example.org/pizza#America'"
-      ]
-     },
-     "execution_count": 67,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "onto.terms.pizza.America.uri"
    ]
   },
   {
@@ -482,7 +427,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "rdf",
    "language": "python",
    "name": "python3"
   },
@@ -496,7 +441,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/pizza.ipynb
+++ b/examples/pizza.ipynb
@@ -1,0 +1,504 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "fe5391cd-0816-4b81-b491-9439b642b0dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tools4rdf.network.network import OntologyNetwork\n",
+    "from rdflib import Graph, Namespace, RDFS, RDF, URIRef, Namespace, Literal, XSD\n",
+    "import pandas as pd\n",
+    "from uuid import uuid4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "cbab587f-a127-4436-81ce-3e625a9ba7bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_id(term):\n",
+    "    return term.strip() + \":\" + str(uuid4()).split(\"-\")[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "39282722-fadf-4b9f-ae66-08ccdf75769d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "onto = OntologyNetwork(\"pizza.owl\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "f792eaa2-90f3-410e-a68d-70f212e71d59",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pizza:hasTopping\n",
+       "Note that hasTopping is inverse functional because isToppingOf is functional"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "onto.terms.pizza.hasSpiciness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "6e51475a-3a39-4247-91f4-93bbb117d170",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"pizza_kg.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "58313894-d0c7-451f-82e4-a0efc6dcec00",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>PIZZA</th>\n",
+       "      <th>PIZZABASE</th>\n",
+       "      <th>PIZZATOPPING1</th>\n",
+       "      <th>CALORIFICCONTENTVALUE</th>\n",
+       "      <th>PIZZATOPPING2</th>\n",
+       "      <th>CALORIFICCONTENTVALUE2</th>\n",
+       "      <th>PIZZATOPPING3</th>\n",
+       "      <th>CALORIFICCONTENTVALUE3</th>\n",
+       "      <th>PIZZATOPPING4</th>\n",
+       "      <th>CALORIFICCONTENTVALUE4</th>\n",
+       "      <th>FOOD</th>\n",
+       "      <th>PRICE</th>\n",
+       "      <th>SPICINESS</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>IceCream</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>Milk</td>\n",
+       "      <td>7.00</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>American</td>\n",
+       "      <td>PizzaBase</td>\n",
+       "      <td>MozzarellaTopping</td>\n",
+       "      <td>280</td>\n",
+       "      <td>PeperoniSausageTopping</td>\n",
+       "      <td>494</td>\n",
+       "      <td>TomatoTopping</td>\n",
+       "      <td>18</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>10.00</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AmericanHot</td>\n",
+       "      <td>PizzaBase</td>\n",
+       "      <td>MozzarellaTopping</td>\n",
+       "      <td>280</td>\n",
+       "      <td>PeperoniSausageTopping</td>\n",
+       "      <td>494</td>\n",
+       "      <td>TomatoTopping</td>\n",
+       "      <td>18</td>\n",
+       "      <td>JalapenoPepperTopping</td>\n",
+       "      <td>29</td>\n",
+       "      <td>-</td>\n",
+       "      <td>11.50</td>\n",
+       "      <td>Hot</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Margherita</td>\n",
+       "      <td>DeepPanBase</td>\n",
+       "      <td>MozzarellaTopping</td>\n",
+       "      <td>280</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>TomatoTopping</td>\n",
+       "      <td>18</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>9.50</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Margherita</td>\n",
+       "      <td>ThinAndCrispyBase</td>\n",
+       "      <td>MozzarellaTopping</td>\n",
+       "      <td>280</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>TomatoTopping</td>\n",
+       "      <td>18</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>8.99</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Mushroom</td>\n",
+       "      <td>PizzaBase</td>\n",
+       "      <td>MozzarellaTopping</td>\n",
+       "      <td>280</td>\n",
+       "      <td>MushroomTopping</td>\n",
+       "      <td>22</td>\n",
+       "      <td>TomatoTopping</td>\n",
+       "      <td>18</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>11.00</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>SpicyPizza</td>\n",
+       "      <td>PizzaBase</td>\n",
+       "      <td>MozzarellaTopping</td>\n",
+       "      <td>280</td>\n",
+       "      <td>SweetPepperTopping</td>\n",
+       "      <td>26</td>\n",
+       "      <td>TomatoTopping</td>\n",
+       "      <td>18</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>12.99</td>\n",
+       "      <td>Mild</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>SpicyPizza</td>\n",
+       "      <td>PizzaBase</td>\n",
+       "      <td>MozzarellaTopping</td>\n",
+       "      <td>280</td>\n",
+       "      <td>HotGreenPepperTopping</td>\n",
+       "      <td>40</td>\n",
+       "      <td>TomatoTopping</td>\n",
+       "      <td>18</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>-</td>\n",
+       "      <td>11.00</td>\n",
+       "      <td>Hot</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>VegetarianPizza</td>\n",
+       "      <td>PizzaBase</td>\n",
+       "      <td>MozzarellaTopping</td>\n",
+       "      <td>280</td>\n",
+       "      <td>ArtichokeTopping</td>\n",
+       "      <td>47</td>\n",
+       "      <td>TomatoTopping</td>\n",
+       "      <td>18</td>\n",
+       "      <td>OliveTopping</td>\n",
+       "      <td>115</td>\n",
+       "      <td>-</td>\n",
+       "      <td>11.50</td>\n",
+       "      <td>-</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             PIZZA          PIZZABASE      PIZZATOPPING1  \\\n",
+       "0         IceCream                  -                  -   \n",
+       "1         American          PizzaBase  MozzarellaTopping   \n",
+       "2      AmericanHot          PizzaBase  MozzarellaTopping   \n",
+       "3       Margherita        DeepPanBase  MozzarellaTopping   \n",
+       "4       Margherita  ThinAndCrispyBase  MozzarellaTopping   \n",
+       "5         Mushroom          PizzaBase  MozzarellaTopping   \n",
+       "6       SpicyPizza          PizzaBase  MozzarellaTopping   \n",
+       "7       SpicyPizza          PizzaBase  MozzarellaTopping   \n",
+       "8  VegetarianPizza          PizzaBase  MozzarellaTopping   \n",
+       "\n",
+       "  CALORIFICCONTENTVALUE           PIZZATOPPING2 CALORIFICCONTENTVALUE2  \\\n",
+       "0                     -                       -                      -   \n",
+       "1                   280  PeperoniSausageTopping                    494   \n",
+       "2                   280  PeperoniSausageTopping                    494   \n",
+       "3                   280                       -                      -   \n",
+       "4                   280                       -                      -   \n",
+       "5                   280         MushroomTopping                     22   \n",
+       "6                   280      SweetPepperTopping                     26   \n",
+       "7                   280   HotGreenPepperTopping                     40   \n",
+       "8                   280        ArtichokeTopping                     47   \n",
+       "\n",
+       "   PIZZATOPPING3 CALORIFICCONTENTVALUE3          PIZZATOPPING4  \\\n",
+       "0              -                      -                      -   \n",
+       "1  TomatoTopping                     18                      -   \n",
+       "2  TomatoTopping                     18  JalapenoPepperTopping   \n",
+       "3  TomatoTopping                     18                      -   \n",
+       "4  TomatoTopping                     18                      -   \n",
+       "5  TomatoTopping                     18                      -   \n",
+       "6  TomatoTopping                     18                      -   \n",
+       "7  TomatoTopping                     18                      -   \n",
+       "8  TomatoTopping                     18           OliveTopping   \n",
+       "\n",
+       "  CALORIFICCONTENTVALUE4  FOOD  PRICE SPICINESS  \n",
+       "0                      -  Milk   7.00         -  \n",
+       "1                      -     -  10.00         -  \n",
+       "2                     29     -  11.50       Hot  \n",
+       "3                      -     -   9.50         -  \n",
+       "4                      -     -   8.99         -  \n",
+       "5                      -     -  11.00         -  \n",
+       "6                      -     -  12.99      Mild  \n",
+       "7                      -     -  11.00       Hot  \n",
+       "8                    115     -  11.50         -  "
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "33809ed9-73e1-4660-bfb4-f8c538cd1403",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = Graph()\n",
+    "nm = Namespace('https://example.org/pizza#')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "a07b7f0b-4d07-4b47-89c4-e36e0a2e9bf0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "termdict = {}\n",
+    "\n",
+    "for index, row in df.iterrows():\n",
+    "    pid = get_id(str(row[\"PIZZA\"]))\n",
+    "    term = URIRef(pid)\n",
+    "    g.add((term, RDF.type, getattr(nm, str(row[\"PIZZA\"]))))\n",
+    "\n",
+    "    #add base\n",
+    "    pizzabase = str(row[\"PIZZABASE\"])\n",
+    "    if pizzabase != \"-\":\n",
+    "        if pizzabase in termdict.keys():\n",
+    "            baseid = termdict['pizzabase']\n",
+    "        else:\n",
+    "            baseid = get_id(pizzabase)\n",
+    "            termdict[pizzabase] = baseid\n",
+    "            g.add((baseid, RDF.type, getattr(nm, pizzabase)))\n",
+    "        \n",
+    "        g.add((term, nm.hasBase, baseid))\n",
+    "        \n",
+    "\n",
+    "    #add toppings\n",
+    "    toppings = [\"PIZZATOPPING1\", \"PIZZATOPPING2\", \"PIZZATOPPING3\", \"PIZZATOPPING4\"]\n",
+    "    calories = [\"CALORIFICCONTENTVALUE\", \"CALORIFICCONTENTVALUE2\", \"CALORIFICCONTENTVALUE3\", \"CALORIFICCONTENTVALUE4\"]\n",
+    "    for (topping, calorie) in zip(toppings, calories):\n",
+    "        topbase = str(row[topping])\n",
+    "        if topbase != \"-\":\n",
+    "            \n",
+    "            g.add((term, nm.hasTopping, getattr(nm, topbase)))  \n",
+    "        \n",
+    "        calbase = str(row[calorie])\n",
+    "        if calbase != \"-\":\n",
+    "            g.add((getattr(nm, topbase), nm.hasCalorificContentValue, Literal(float(calbase), datatype=XSD.float)))  \n",
+    "\n",
+    "    #add base\n",
+    "    food = str(row[\"FOOD\"])\n",
+    "    if food != \"-\":\n",
+    "        g.add((term, nm.hasIngredient, getattr(nm, food)))\n",
+    "\n",
+    "    #add base\n",
+    "    price = str(row[\"PRICE\"])\n",
+    "    if price != \"-\":\n",
+    "        g.add((term, nm.hasPrice, Literal(float(price), datatype=XSD.float)))\n",
+    "\n",
+    "    #add base\n",
+    "    spice = str(row[\"SPICINESS\"])\n",
+    "    if spice != \"-\":\n",
+    "        g.add((term, nm.hasSpiciness, getattr(nm, spice)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "ec496e8e-20f6-42c2-bdbc-d2d2dbb58712",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Graph identifier=N98c82271415740269863148d9e78b94a (<class 'rdflib.graph.Graph'>)>"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.serialize(\"pizza_kg.ttl\", format=\"turtle\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "13a31b25-6adc-4b77-aeb2-9eeb1dbbeb0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'brick': 'https://brickschema.org/schema/Brick#',\n",
+       " 'csvw': 'http://www.w3.org/ns/csvw#',\n",
+       " 'dc': 'http://purl.org/dc/elements/1.1/',\n",
+       " 'dcat': 'http://www.w3.org/ns/dcat#',\n",
+       " 'dcmitype': 'http://purl.org/dc/dcmitype/',\n",
+       " 'dcterms': 'http://purl.org/dc/terms/',\n",
+       " 'dcam': 'http://purl.org/dc/dcam/',\n",
+       " 'doap': 'http://usefulinc.com/ns/doap#',\n",
+       " 'foaf': 'http://xmlns.com/foaf/0.1/',\n",
+       " 'geo': 'http://www.opengis.net/ont/geosparql#',\n",
+       " 'odrl': 'http://www.w3.org/ns/odrl/2/',\n",
+       " 'org': 'http://www.w3.org/ns/org#',\n",
+       " 'prof': 'http://www.w3.org/ns/dx/prof/',\n",
+       " 'prov': 'http://www.w3.org/ns/prov#',\n",
+       " 'qb': 'http://purl.org/linked-data/cube#',\n",
+       " 'schema': 'https://schema.org/',\n",
+       " 'sh': 'http://www.w3.org/ns/shacl#',\n",
+       " 'skos': 'http://www.w3.org/2004/02/skos/core#',\n",
+       " 'sosa': 'http://www.w3.org/ns/sosa/',\n",
+       " 'ssn': 'http://www.w3.org/ns/ssn/',\n",
+       " 'time': 'http://www.w3.org/2006/time#',\n",
+       " 'vann': 'http://purl.org/vocab/vann/',\n",
+       " 'void': 'http://rdfs.org/ns/void#',\n",
+       " 'wgs': 'https://www.w3.org/2003/01/geo/wgs84_pos#',\n",
+       " 'owl': 'http://www.w3.org/2002/07/owl#',\n",
+       " 'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',\n",
+       " 'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',\n",
+       " 'xsd': 'http://www.w3.org/2001/XMLSchema#',\n",
+       " 'xml': 'http://www.w3.org/XML/1998/namespace',\n",
+       " 'pizza': 'https://example.org/pizza'}"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "onto.namespaces"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "983e499f-4f46-4e99-a5c5-d3daa0a93a97",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://example.org/pizza#America'"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "onto.terms.pizza.America.uri"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de0a70e9-6990-4688-aebc-8418c9b656e3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/pizza.owl
+++ b/examples/pizza.owl
@@ -1,0 +1,3012 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns:pizza="https://example.org/pizza#"
+     xml:base="https://example.org/pizza#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="https://example.org/pizza#">
+        <rdfs:comment xml:lang="en">An example ontology that contains all constructs required for the various versions of the Pizza Tutorial run by Manchester University</rdfs:comment>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This is an example pizza ontology based on the 1.5 version. Edited for working with the tools4RDF python toolkit.</rdfs:comment>
+        <owl:versionInfo xml:lang="en">v.1.4. Added Food class (used in domain/range of hasIngredient), Added several hasCountryOfOrigin restrictions on pizzas, Made hasTopping invers functional</owl:versionInfo>
+        <owl:versionInfo xml:lang="en">v.1.5. Removed protege.owl import and references. Made ontology URI date-independent</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">version 1.5</owl:versionInfo>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://example.org/pizza#hasBase -->
+
+    <owl:ObjectProperty rdf:about="https://example.org/pizza#hasBase">
+        <rdfs:subPropertyOf rdf:resource="https://example.org/pizza#hasIngredient"/>
+        <owl:inverseOf rdf:resource="https://example.org/pizza#isBaseOf"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://example.org/pizza#Pizza"/>
+        <rdfs:range rdf:resource="https://example.org/pizza#PizzaBase"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://example.org/pizza#hasCountryOfOrigin -->
+
+    <owl:ObjectProperty rdf:about="https://example.org/pizza#hasCountryOfOrigin"/>
+    
+
+
+    <!-- https://example.org/pizza#hasIngredient -->
+
+    <owl:ObjectProperty rdf:about="https://example.org/pizza#hasIngredient">
+        <owl:inverseOf rdf:resource="https://example.org/pizza#isIngredientOf"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:domain rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:range rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:comment xml:lang="en">NB Transitive - the ingredients of ingredients are ingredients of the whole</rdfs:comment>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://example.org/pizza#hasSpiciness -->
+
+    <owl:ObjectProperty rdf:about="https://example.org/pizza#hasSpiciness">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:range rdf:resource="https://example.org/pizza#Spiciness"/>
+        <rdfs:comment xml:lang="en">A property created to be used with the ValuePartition - Spiciness.</rdfs:comment>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://example.org/pizza#hasTopping -->
+
+    <owl:ObjectProperty rdf:about="https://example.org/pizza#hasTopping">
+        <rdfs:subPropertyOf rdf:resource="https://example.org/pizza#hasIngredient"/>
+        <owl:inverseOf rdf:resource="https://example.org/pizza#isToppingOf"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://example.org/pizza#Pizza"/>
+        <rdfs:range rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <rdfs:comment xml:lang="en">Note that hasTopping is inverse functional because isToppingOf is functional</rdfs:comment>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://example.org/pizza#isBaseOf -->
+
+    <owl:ObjectProperty rdf:about="https://example.org/pizza#isBaseOf">
+        <rdfs:subPropertyOf rdf:resource="https://example.org/pizza#isIngredientOf"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://example.org/pizza#PizzaBase"/>
+        <rdfs:range rdf:resource="https://example.org/pizza#Pizza"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://example.org/pizza#isIngredientOf -->
+
+    <owl:ObjectProperty rdf:about="https://example.org/pizza#isIngredientOf">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:domain rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:range rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:comment xml:lang="en">The inverse property tree to hasIngredient - all subproperties and attributes of the properties should reflect those under hasIngredient.</rdfs:comment>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://example.org/pizza#isToppingOf -->
+
+    <owl:ObjectProperty rdf:about="https://example.org/pizza#isToppingOf">
+        <rdfs:subPropertyOf rdf:resource="https://example.org/pizza#isIngredientOf"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <rdfs:range rdf:resource="https://example.org/pizza#Pizza"/>
+        <rdfs:comment xml:lang="en">Any given instance of topping should only be added to a single pizza (no cheap half-measures on our pizzas)</rdfs:comment>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://example.org/pizza/hasCalorificContentValue -->
+
+    <owl:DatatypeProperty rdf:about="https://example.org/pizza/hasCalorificContentValue">
+        <rdfs:domain rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Relates an ingredient to the calorific content, in calories per 100 grams.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hasCalorificContentValue</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://example.org/pizza/hasPrice -->
+
+    <owl:DatatypeProperty rdf:about="https://example.org/pizza/hasPrice">
+        <rdfs:domain rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#float"/>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Relates to the price of a food item, in euros.</rdfs:comment>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hasPrice</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://example.org/pizza#American -->
+
+    <owl:Class rdf:about="https://example.org/pizza#American">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PeperoniSausageTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PeperoniSausageTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="https://example.org/pizza#America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#AmericanHot"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Cajun"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Capricciosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Caprina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Fiorentina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FourSeasons"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Giardiniera"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Americana</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#AmericanHot -->
+
+    <owl:Class rdf:about="https://example.org/pizza#AmericanHot">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#HotGreenPepperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#JalapenoPepperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PeperoniSausageTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#HotGreenPepperTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#JalapenoPepperTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PeperoniSausageTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="https://example.org/pizza#America"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Cajun"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Capricciosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Caprina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Fiorentina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FourSeasons"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Giardiniera"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">AmericanaPicante</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#AnchoviesTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#AnchoviesTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#FishTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MixedSeafoodTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrawnsTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeAnchovies</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#ArtichokeTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#ArtichokeTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#AsparagusTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#CaperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#GarlicTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LeekTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OliveTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OnionTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeArtichoke</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#AsparagusTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#AsparagusTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#CaperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#GarlicTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LeekTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OliveTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OnionTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeAspargos</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Cajun -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Cajun">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OnionTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PeperonataTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PrawnsTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TobascoPepperSauce"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OnionTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PeperonataTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PrawnsTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TobascoPepperSauce"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Capricciosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Caprina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Fiorentina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FourSeasons"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Giardiniera"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Cajun</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#CajunSpiceTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#CajunSpiceTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#HerbSpiceTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RosemaryTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeCajun</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#CaperTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#CaperTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#GarlicTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LeekTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OliveTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OnionTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeCaper</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Capricciosa -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Capricciosa">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#AnchoviesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#CaperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#HamTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PeperonataTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#AnchoviesTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#CaperTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#HamTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PeperonataTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Caprina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Fiorentina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FourSeasons"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Giardiniera"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Capricciosa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Caprina -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Caprina">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#GoatsCheeseTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#SundriedTomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#GoatsCheeseTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#SundriedTomatoTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Fiorentina"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FourSeasons"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Giardiniera"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Caprina</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#CheeseTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#CheeseTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FishTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruitTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#HerbSpiceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MeatTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#NutTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SauceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeQueijo</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#CheeseyPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#CheeseyPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                        <owl:someValuesFrom rdf:resource="https://example.org/pizza#CheeseTopping"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">Any pizza that has at least 1 cheese topping.</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaComQueijo</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#CheeseyVegetableTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#CheeseyVegetableTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#CheeseTopping"/>
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:comment xml:lang="en">This class will be inconsistent. This is because we have given it 2 disjoint parents, which means it could never have any members (as nothing can simultaneously be a CheeseTopping and a VegetableTopping). NB Called ProbeInconsistentTopping in the ProtegeOWL Tutorial.</rdfs:comment>
+        <rdfs:label xml:lang="pt">CoberturaDeQueijoComVegetais</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#ChickenTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#ChickenTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#MeatTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#HamTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#HotSpicedBeefTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PeperoniSausageTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeFrango</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Country -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Country">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#DomainConcept"/>
+                    <owl:Class>
+                        <owl:oneOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#America"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#England"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#France"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#Germany"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#Italy"/>
+                        </owl:oneOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">A class that is equivalent to the set of individuals that are described in the enumeration - ie Countries can only be either America, England, France, Germany or Italy and nothing else. Note that these individuals have been asserted to be allDifferent from each other.</rdfs:comment>
+        <rdfs:label xml:lang="pt">Pais</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#DeepPanBase -->
+
+    <owl:Class rdf:about="https://example.org/pizza#DeepPanBase">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaBase"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#ThinAndCrispyBase"/>
+        <rdfs:label xml:lang="pt">BaseEspessa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#DomainConcept -->
+
+    <owl:Class rdf:about="https://example.org/pizza#DomainConcept">
+        <owl:disjointWith rdf:resource="https://example.org/pizza#ValuePartition"/>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Fiorentina -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Fiorentina">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#ParmesanTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#SpinachTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#GarlicTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#ParmesanTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#SpinachTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FourSeasons"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Giardiniera"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Fiorentina</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#FishTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#FishTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruitTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#HerbSpiceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MeatTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#NutTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SauceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDePeixe</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Food -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Food">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#DomainConcept"/>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#FourCheesesTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#FourCheesesTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#GoatsCheeseTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#GorgonzolaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#ParmesanTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaQuatroQueijos</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#FourSeasons -->
+
+    <owl:Class rdf:about="https://example.org/pizza#FourSeasons">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#AnchoviesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#CaperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MushroomTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PeperoniSausageTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#AnchoviesTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#CaperTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MushroomTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PeperoniSausageTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#FruttiDiMare"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Giardiniera"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">QuatroQueijos</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#FruitTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#FruitTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#HerbSpiceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MeatTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#NutTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SauceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeFrutas</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#FruttiDiMare -->
+
+    <owl:Class rdf:about="https://example.org/pizza#FruttiDiMare">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MixedSeafoodTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#GarlicTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MixedSeafoodTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Giardiniera"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">FrutosDoMar</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#GarlicTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#GarlicTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LeekTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OliveTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OnionTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeAlho</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Giardiniera -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Giardiniera">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#LeekTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MushroomTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PeperonataTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#SlicedTomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#LeekTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MushroomTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PeperonataTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PetitPoisTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#SlicedTomatoTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#LaReine"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Giardiniera</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#GoatsCheeseTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#GoatsCheeseTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#GorgonzolaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#ParmesanTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeQueijoDeCabra</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#GorgonzolaTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#GorgonzolaTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#ParmesanTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeGorgonzola</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#GreenPepperTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#GreenPepperTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#JalapenoPepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PeperonataTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SweetPepperTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDePimentaoVerde</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#HamTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#HamTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#MeatTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#HotSpicedBeefTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PeperoniSausageTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDePresunto</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#HerbSpiceTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#HerbSpiceTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MeatTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#NutTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SauceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeErvas</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Hot -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Hot">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#Spiciness"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Medium"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mild"/>
+        <rdfs:label xml:lang="pt">Picante</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#HotGreenPepperTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#HotGreenPepperTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#GreenPepperTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaDePimentaoVerdePicante</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#HotSpicedBeefTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#HotSpicedBeefTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#MeatTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PeperoniSausageTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeBifePicante</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#IceCream -->
+
+    <owl:Class rdf:about="https://example.org/pizza#IceCream">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#FruitTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Pizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PizzaBase"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <rdfs:comment xml:lang="en">A class to demonstrate mistakes made with setting a property domain. The property hasTopping has a domain of Pizza. This means that the reasoner can infer that all individuals using the hasTopping property must be of type Pizza. Because of the restriction on this class, all members of IceCream must use the hasTopping property, and therefore must also be members of Pizza. However, Pizza and IceCream are disjoint, so this causes an inconsistency. If they were not disjoint, IceCream would be inferred to be a subclass of Pizza.</rdfs:comment>
+        <rdfs:label xml:lang="pt">Sorvete</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#InterestingPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#InterestingPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                        <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">3</owl:minCardinality>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">Any pizza that has at least 3 toppings. Note that this is a cardinality constraint on the hasTopping property and NOT a qualified cardinality constraint (QCR). A QCR would specify from which class the members in this relationship must be. eg has at least 3 toppings from PizzaTopping. This is currently not supported in OWL.</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaInteressante</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#JalapenoPepperTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#JalapenoPepperTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PeperonataTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SweetPepperTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeJalapeno</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#LaReine -->
+
+    <owl:Class rdf:about="https://example.org/pizza#LaReine">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#HamTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MushroomTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#HamTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MushroomTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Margherita"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">LaReine</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#LeekTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#LeekTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#MushroomTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OliveTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OnionTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeLeek</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Margherita -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Margherita">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mushroom"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Margherita</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#MeatTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#MeatTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#NutTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SauceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeCarne</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#MeatyPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#MeatyPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                        <owl:someValuesFrom rdf:resource="https://example.org/pizza#MeatTopping"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">Any pizza that has at least one meat topping</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaDeCarne</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Medium -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Medium">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#Spiciness"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Mild"/>
+        <rdfs:label xml:lang="pt">Media</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Mild -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Mild">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#Spiciness"/>
+        <rdfs:label xml:lang="pt">NaoPicante</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#MixedSeafoodTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#MixedSeafoodTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#FishTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrawnsTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeFrutosDoMarMistos</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#MozzarellaTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#MozzarellaTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="https://example.org/pizza#Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#ParmesanTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeMozzarella</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Mushroom -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Mushroom">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MushroomTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MushroomTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Napoletana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Cogumelo</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#MushroomTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#MushroomTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OliveTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OnionTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeCogumelo</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#NamedPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#NamedPizza">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#Pizza"/>
+        <rdfs:comment xml:lang="en">A pizza that can be found on a pizza menu</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaComUmNome</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Napoletana -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Napoletana">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#AnchoviesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#CaperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#AnchoviesTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#CaperTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="https://example.org/pizza#Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Parmense"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Napoletana</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#NonVegetarianPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#NonVegetarianPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Class>
+                        <owl:complementOf rdf:resource="https://example.org/pizza#VegetarianPizza"/>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#VegetarianPizza"/>
+        <rdfs:comment xml:lang="en">Any Pizza that is not a VegetarianPizza</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaNaoVegetariana</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#NutTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#NutTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SauceTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeCastanha</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#OliveTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#OliveTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#OnionTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeAzeitona</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#OnionTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#OnionTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeCebola</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#ParmaHamTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#ParmaHamTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#HamTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaDePrezuntoParma</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Parmense -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Parmense">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#AsparagusTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#HamTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#ParmesanTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#AsparagusTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#HamTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#ParmesanTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PolloAdAstra"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Parmense</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#ParmesanTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#ParmesanTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#CheeseTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaDeParmesao</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PeperonataTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PeperonataTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SweetPepperTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaPeperonata</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PeperoniSausageTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PeperoniSausageTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#MeatTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaDeCalabreza</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PepperTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PepperTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#SpicyTopping"/>
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PetitPoisTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDePimentao</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PetitPoisTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PetitPoisTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#RocketTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaPetitPois</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PineKernels -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PineKernels">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NutTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaPineKernels</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Pizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Pizza">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasBase"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PizzaBase"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PizzaBase"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <rdfs:label xml:lang="en">Pizza</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PizzaBase -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PizzaBase">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#Food"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <rdfs:label xml:lang="pt">BaseDaPizza</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PizzaTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PizzaTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#Food"/>
+        <rdfs:label xml:lang="pt">CoberturaDaPizza</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PolloAdAstra -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PolloAdAstra">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#CajunSpiceTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#ChickenTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#RedOnionTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#SweetPepperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#CajunSpiceTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#ChickenTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#GarlicTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#RedOnionTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#SweetPepperTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#PrinceCarlo"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">PolloAdAstra</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PrawnsTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PrawnsTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#FishTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeCamarao</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#PrinceCarlo -->
+
+    <owl:Class rdf:about="https://example.org/pizza#PrinceCarlo">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#LeekTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#ParmesanTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#RosemaryTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#LeekTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#ParmesanTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#RosemaryTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#QuattroFormaggi"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">CoberturaPrinceCarlo</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#QuattroFormaggi -->
+
+    <owl:Class rdf:about="https://example.org/pizza#QuattroFormaggi">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#FourCheesesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#FourCheesesTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Rosa"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">QuatroQueijos</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#RealItalianPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#RealItalianPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasCountryOfOrigin"/>
+                        <owl:hasValue rdf:resource="https://example.org/pizza#Italy"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasBase"/>
+                <owl:allValuesFrom rdf:resource="https://example.org/pizza#ThinAndCrispyBase"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">This defined class has conditions that are part of the definition: ie any Pizza that has the country of origin, Italy is a RealItalianPizza. It also has conditions that merely describe the members - that all RealItalianPizzas must only have ThinAndCrispy bases. In essence, all pizzas from Italy must have ThinAndCrispy bases.</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaItalianaReal</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#RedOnionTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#RedOnionTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#OnionTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeCebolaVermelha</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#RocketTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#RocketTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SpinachTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaRocket</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Rosa -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Rosa">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#GorgonzolaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#GorgonzolaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Siciliana"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Rosa</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#RosemaryTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#RosemaryTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#HerbSpiceTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaRosemary</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SauceTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SauceTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaEmMolho</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Siciliana -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Siciliana">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#AnchoviesTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#ArtichokeTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#HamTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#AnchoviesTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#ArtichokeTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#GarlicTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#HamTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SloppyGiuseppe"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Siciliana</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SlicedTomatoTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SlicedTomatoTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#SundriedTomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeTomateFatiado</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SloppyGiuseppe -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SloppyGiuseppe">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#GreenPepperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#HotSpicedBeefTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OnionTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#GreenPepperTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#HotSpicedBeefTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OnionTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Soho"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">SloppyGiuseppe</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Soho -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Soho">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#GarlicTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#ParmesanTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#RocketTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#GarlicTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#ParmesanTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#RocketTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#UnclosedPizza"/>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:label xml:lang="pt">Soho</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Spiciness -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Spiciness">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:unionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Hot"/>
+                    <rdf:Description rdf:about="https://example.org/pizza#Medium"/>
+                    <rdf:Description rdf:about="https://example.org/pizza#Mild"/>
+                </owl:unionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#ValuePartition"/>
+        <rdfs:comment xml:lang="en">A ValuePartition that describes only values from Hot, Medium or Mild. NB Subclasses can themselves be divided up into further partitions.</rdfs:comment>
+        <rdfs:label xml:lang="pt">Tempero</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SpicyPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SpicyPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                        <owl:someValuesFrom rdf:resource="https://example.org/pizza#SpicyTopping"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">Any pizza that has a spicy topping is a SpicyPizza</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaTemperada</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SpicyPizzaEquivalent -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SpicyPizzaEquivalent">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                        <owl:someValuesFrom>
+                            <owl:Class>
+                                <owl:intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="https://example.org/pizza#PizzaTopping"/>
+                                    <owl:Restriction>
+                                        <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                                        <owl:someValuesFrom rdf:resource="https://example.org/pizza#Hot"/>
+                                    </owl:Restriction>
+                                </owl:intersectionOf>
+                            </owl:Class>
+                        </owl:someValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">An alternative definition for the SpicyPizza which does away with needing a definition of SpicyTopping and uses a slightly more complicated restriction: Pizzas that have at least one topping that is both a PizzaTopping and has spiciness hot are members of this class.</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaTemperadaEquivalente</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SpicyTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SpicyTopping">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#PizzaTopping"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                        <owl:someValuesFrom rdf:resource="https://example.org/pizza#Hot"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">Any pizza topping that has spiciness Hot</rdfs:comment>
+        <rdfs:label xml:lang="pt">CoberturaTemperada</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SpinachTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SpinachTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeEspinafre</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SultanaTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SultanaTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#FruitTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Medium"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaSultana</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SundriedTomatoTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SundriedTomatoTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#TomatoTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaDeTomateRessecadoAoSol</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#SweetPepperTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#SweetPepperTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PepperTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaDePimentaoDoce</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#ThinAndCrispyBase -->
+
+    <owl:Class rdf:about="https://example.org/pizza#ThinAndCrispyBase">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaBase"/>
+        <rdfs:label xml:lang="pt">BaseFinaEQuebradica</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#ThinAndCrispyPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#ThinAndCrispyPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasBase"/>
+                        <owl:allValuesFrom rdf:resource="https://example.org/pizza#ThinAndCrispyBase"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#TobascoPepperSauce -->
+
+    <owl:Class rdf:about="https://example.org/pizza#TobascoPepperSauce">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#SauceTopping"/>
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#SpicyTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Hot"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">MolhoTobascoPepper</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#TomatoTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#TomatoTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#VegetableTopping"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasSpiciness"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#Mild"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">CoberturaDeTomate</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#UnclosedPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#UnclosedPizza">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <owl:disjointWith rdf:resource="https://example.org/pizza#Veneziana"/>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An unclosed Pizza cannot be inferred to be either a VegetarianPizza or a NonVegetarianPizza, because it might have other toppings.</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaAberta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#ValuePartition -->
+
+    <owl:Class rdf:about="https://example.org/pizza#ValuePartition">
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ValuePartition is a pattern that describes a restricted set of classes from which a property can be associated. The parent class is used in restrictions, and the covering axiom means that only members of the subclasses may be used as values. The possible subclasses cannot be extended without updating the ValuePartition class.</rdfs:comment>
+        <rdfs:label xml:lang="pt">ValorDaParticao</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#VegetableTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#VegetableTopping">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#PizzaTopping"/>
+        <rdfs:label xml:lang="pt">CoberturaDeVegetais</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#VegetarianPizza -->
+
+    <owl:Class rdf:about="https://example.org/pizza#VegetarianPizza">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Class>
+                        <owl:complementOf>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                                <owl:someValuesFrom rdf:resource="https://example.org/pizza#FishTopping"/>
+                            </owl:Restriction>
+                        </owl:complementOf>
+                    </owl:Class>
+                    <owl:Class>
+                        <owl:complementOf>
+                            <owl:Restriction>
+                                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MeatTopping"/>
+                            </owl:Restriction>
+                        </owl:complementOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">Any pizza that does not have fish topping and does not have meat topping is a VegetarianPizza. Members of this class do not need to have any toppings at all.</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaVegetariana</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#VegetarianPizzaEquivalent1 -->
+
+    <owl:Class rdf:about="https://example.org/pizza#VegetarianPizzaEquivalent1">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                        <owl:allValuesFrom rdf:resource="https://example.org/pizza#VegetarianTopping"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">Any pizza that only has vegetarian toppings or no toppings is a VegetarianPizzaEquiv1. Should be inferred to be equivalent to VegetarianPizzaEquiv2.  Not equivalent to VegetarianPizza because PizzaTopping is not covering</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaVegetarianaEquivalente1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#VegetarianPizzaEquivalent2 -->
+
+    <owl:Class rdf:about="https://example.org/pizza#VegetarianPizzaEquivalent2">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#Pizza"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                        <owl:allValuesFrom>
+                            <owl:Class>
+                                <owl:unionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="https://example.org/pizza#CheeseTopping"/>
+                                    <rdf:Description rdf:about="https://example.org/pizza#FruitTopping"/>
+                                    <rdf:Description rdf:about="https://example.org/pizza#HerbSpiceTopping"/>
+                                    <rdf:Description rdf:about="https://example.org/pizza#NutTopping"/>
+                                    <rdf:Description rdf:about="https://example.org/pizza#SauceTopping"/>
+                                    <rdf:Description rdf:about="https://example.org/pizza#VegetableTopping"/>
+                                </owl:unionOf>
+                            </owl:Class>
+                        </owl:allValuesFrom>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">An alternative to VegetarianPizzaEquiv1 that does not require a definition of VegetarianTopping. Perhaps more difficult to maintain. Not equivalent to VegetarianPizza</rdfs:comment>
+        <rdfs:label xml:lang="pt">PizzaVegetarianaEquivalente2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#VegetarianTopping -->
+
+    <owl:Class rdf:about="https://example.org/pizza#VegetarianTopping">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://example.org/pizza#PizzaTopping"/>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#CheeseTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#FruitTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#HerbSpiceTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#NutTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#SauceTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#VegetableTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:comment xml:lang="en">An example of a covering axiom. VegetarianTopping is equivalent to the union of all toppings in the given axiom. VegetarianToppings can only be Cheese or Vegetable or....etc.</rdfs:comment>
+        <rdfs:label xml:lang="pt">CoberturaVegetariana</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://example.org/pizza#Veneziana -->
+
+    <owl:Class rdf:about="https://example.org/pizza#Veneziana">
+        <rdfs:subClassOf rdf:resource="https://example.org/pizza#NamedPizza"/>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#CaperTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#MozzarellaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OliveTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#OnionTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#PineKernels"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#SultanaTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:someValuesFrom rdf:resource="https://example.org/pizza#TomatoTopping"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasTopping"/>
+                <owl:allValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://example.org/pizza#CaperTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#MozzarellaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OliveTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#OnionTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#PineKernels"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#SultanaTopping"/>
+                            <rdf:Description rdf:about="https://example.org/pizza#TomatoTopping"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:allValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://example.org/pizza#hasCountryOfOrigin"/>
+                <owl:hasValue rdf:resource="https://example.org/pizza#Italy"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="pt">Veneziana</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://example.org/pizza#America -->
+
+    <owl:Thing rdf:about="https://example.org/pizza#America">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="https://example.org/pizza#Country"/>
+    </owl:Thing>
+    
+
+
+    <!-- https://example.org/pizza#England -->
+
+    <owl:Thing rdf:about="https://example.org/pizza#England">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="https://example.org/pizza#Country"/>
+    </owl:Thing>
+    
+
+
+    <!-- https://example.org/pizza#France -->
+
+    <owl:Thing rdf:about="https://example.org/pizza#France">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="https://example.org/pizza#Country"/>
+    </owl:Thing>
+    
+
+
+    <!-- https://example.org/pizza#Germany -->
+
+    <owl:Thing rdf:about="https://example.org/pizza#Germany">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="https://example.org/pizza#Country"/>
+    </owl:Thing>
+    
+
+
+    <!-- https://example.org/pizza#Italy -->
+
+    <owl:Thing rdf:about="https://example.org/pizza#Italy">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+        <rdf:type rdf:resource="https://example.org/pizza#Country"/>
+    </owl:Thing>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="https://example.org/pizza#America"/>
+            <rdf:Description rdf:about="https://example.org/pizza#England"/>
+            <rdf:Description rdf:about="https://example.org/pizza#France"/>
+            <rdf:Description rdf:about="https://example.org/pizza#Germany"/>
+            <rdf:Description rdf:about="https://example.org/pizza#Italy"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+

--- a/examples/pizza_kg.csv
+++ b/examples/pizza_kg.csv
@@ -1,0 +1,10 @@
+PIZZA,PIZZABASE,PIZZATOPPING1,CALORIFICCONTENTVALUE,PIZZATOPPING2,CALORIFICCONTENTVALUE2,PIZZATOPPING3,CALORIFICCONTENTVALUE3,PIZZATOPPING4,CALORIFICCONTENTVALUE4,FOOD,PRICE,SPICINESS
+IceCream,-,-,-,-,-,-,-,-,-,Milk,7,-
+American,PizzaBase,MozzarellaTopping,280,PeperoniSausageTopping,494,TomatoTopping,18,-,-,-,10,-
+AmericanHot,PizzaBase,MozzarellaTopping,280,PeperoniSausageTopping,494,TomatoTopping,18,JalapenoPepperTopping,29,-,11.5,Hot
+Margherita,DeepPanBase,MozzarellaTopping,280,-,-,TomatoTopping,18,-,-,-,9.5,-
+Margherita,ThinAndCrispyBase,MozzarellaTopping,280,-,-,TomatoTopping,18,-,-,-,8.99,-
+Mushroom,PizzaBase,MozzarellaTopping,280,MushroomTopping,22,TomatoTopping,18,-,-,-,11,-
+SpicyPizza,PizzaBase,MozzarellaTopping,280,SweetPepperTopping,26,TomatoTopping,18,-,-,-,12.99,Mild
+SpicyPizza,PizzaBase,MozzarellaTopping,280,HotGreenPepperTopping,40,TomatoTopping,18,-,-,-,11,Hot
+VegetarianPizza,PizzaBase,MozzarellaTopping,280,ArtichokeTopping,47,TomatoTopping,18,OliveTopping,115,-,11.5,-

--- a/examples/test.ipynb
+++ b/examples/test.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,16 +21,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=N8654802e12c440ba95ab2c745287559a (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=Neb8e3e4819864d07a1ff529010a47488 (<class 'rdflib.graph.Graph'>)>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -50,23 +50,19 @@
      "output_type": "stream",
      "text": [
       "['Pizza', 'pizza:hasTopping', 'hasTopping']\n",
-      "['hasTopping', 'hasTopping_PeperoniSausageTopping']\n"
+      "['hasTopping', 'hasTopping_PeperoniSausageTopping']\n",
+      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "PREFIX pizza: <https://example.org/pizza#>\n",
+      "SELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\n",
+      "WHERE {\n",
+      "    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\n",
+      "}\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\\nPREFIX pizza: <https://example.org/pizza#>\\nSELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\\nWHERE {\\n    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\\n    ?Pizza rdf:type pizza:Pizza .\\n    ?hasTopping_PeperoniSausageTopping rdf:type pizza:PeperoniSausageTopping .\\n}'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "q = onto.create_query(onto.terms.pizza.Pizza, [[onto.terms.pizza.hasTopping, onto.terms.pizza.PeperoniSausageTopping],])\n",
-    "q"
+    "q = onto.create_query(onto.terms.pizza.Pizza.any, [[onto.terms.pizza.hasTopping, onto.terms.pizza.PeperoniSausageTopping.any],])\n",
+    "print(q)"
    ]
   },
   {
@@ -120,93 +116,6 @@
     "for a in r:\n",
     "    print(a)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(rdflib.term.URIRef('Margherita:5e902c81'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#Margherita'))\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#AmericanHot'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:00e5d4e0'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('11.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('SpicyPizza:0fec2a01'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'))\n",
-      "(rdflib.term.URIRef('American:dea57c44'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'))\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#PeperoniSausageTopping'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:00e5d4e0'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#SpicyPizza'))\n",
-      "(rdflib.term.URIRef('VegetarianPizza:d152923c'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'))\n",
-      "(rdflib.term.URIRef('Margherita:30a3f96f'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'))\n",
-      "(rdflib.term.URIRef('Margherita:5e902c81'), rdflib.term.URIRef('https://example.org/pizza#hasBase'), rdflib.term.URIRef('https://example.org/pizza#DeepPanBase'))\n",
-      "(rdflib.term.URIRef('Mushroom:a8318f66'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'))\n",
-      "(rdflib.term.URIRef('IceCream:4a233997'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#IceCream'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:0fec2a01'), rdflib.term.URIRef('https://example.org/pizza#hasSpiciness'), rdflib.term.URIRef('https://example.org/pizza#Mild'))\n",
-      "(rdflib.term.URIRef('Margherita:5e902c81'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'))\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('11.5', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('IceCream:4a233997'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('7.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('Mushroom:a8318f66'), rdflib.term.URIRef('https://example.org/pizza#hasBase'), rdflib.term.URIRef('https://example.org/pizza#PizzaBase'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:0fec2a01'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('12.99', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#MushroomTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('22.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#JalapenoPepperTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('29.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('SpicyPizza:0fec2a01'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'))\n",
-      "(rdflib.term.URIRef('American:dea57c44'), rdflib.term.URIRef('https://example.org/pizza#hasBase'), rdflib.term.URIRef('https://example.org/pizza#PizzaBase'))\n",
-      "(rdflib.term.URIRef('Margherita:30a3f96f'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('8.99', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#JalapenoPepperTopping'))\n",
-      "(rdflib.term.URIRef('Margherita:30a3f96f'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('280.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('VegetarianPizza:d152923c'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'))\n",
-      "(rdflib.term.URIRef('IceCream:4a233997'), rdflib.term.URIRef('https://example.org/pizza#hasIngredient'), rdflib.term.URIRef('https://example.org/pizza#Milk'))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('18.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'))\n",
-      "(rdflib.term.URIRef('Mushroom:a8318f66'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('11.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('SpicyPizza:00e5d4e0'), rdflib.term.URIRef('https://example.org/pizza#hasSpiciness'), rdflib.term.URIRef('https://example.org/pizza#Hot'))\n",
-      "(rdflib.term.URIRef('VegetarianPizza:d152923c'), rdflib.term.URIRef('https://example.org/pizza#hasBase'), rdflib.term.URIRef('https://example.org/pizza#PizzaBase'))\n",
-      "(rdflib.term.URIRef('Margherita:5e902c81'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('9.5', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('American:dea57c44'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#PeperoniSausageTopping'))\n",
-      "(rdflib.term.URIRef('Margherita:30a3f96f'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#Margherita'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:00e5d4e0'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#HotGreenPepperTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('40.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#OliveTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('115.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('Margherita:30a3f96f'), rdflib.term.URIRef('https://example.org/pizza#hasBase'), rdflib.term.URIRef('https://example.org/pizza#ThinAndCrispyBase'))\n",
-      "(rdflib.term.URIRef('American:dea57c44'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('10.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('SpicyPizza:0fec2a01'), rdflib.term.URIRef('https://example.org/pizza#hasBase'), rdflib.term.URIRef('https://example.org/pizza#PizzaBase'))\n",
-      "(rdflib.term.URIRef('VegetarianPizza:d152923c'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#OliveTopping'))\n",
-      "(rdflib.term.URIRef('VegetarianPizza:d152923c'), rdflib.term.URIRef('https://example.org/pizza#hasPrice'), rdflib.term.Literal('11.5', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'), rdflib.term.URIRef('https://example.org/pizza#hasSpiciness'), rdflib.term.URIRef('https://example.org/pizza#Hot'))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#ArtichokeTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('47.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#PeperoniSausageTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('494.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('Mushroom:a8318f66'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MushroomTopping'))\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'))\n",
-      "(rdflib.term.URIRef('VegetarianPizza:d152923c'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#VegetarianPizza'))\n",
-      "(rdflib.term.URIRef('Mushroom:a8318f66'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#Mushroom'))\n",
-      "(rdflib.term.URIRef('VegetarianPizza:d152923c'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#ArtichokeTopping'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:00e5d4e0'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#HotGreenPepperTopping'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:00e5d4e0'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#MozzarellaTopping'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:0fec2a01'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#SpicyPizza'))\n",
-      "(rdflib.term.URIRef('American:dea57c44'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:0fec2a01'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#SweetPepperTopping'))\n",
-      "(rdflib.term.URIRef('https://example.org/pizza#SweetPepperTopping'), rdflib.term.URIRef('https://example.org/pizza#hasCalorificContentValue'), rdflib.term.Literal('26.0', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#float')))\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'), rdflib.term.URIRef('https://example.org/pizza#hasBase'), rdflib.term.URIRef('https://example.org/pizza#PizzaBase'))\n",
-      "(rdflib.term.URIRef('SpicyPizza:00e5d4e0'), rdflib.term.URIRef('https://example.org/pizza#hasBase'), rdflib.term.URIRef('https://example.org/pizza#PizzaBase'))\n",
-      "(rdflib.term.URIRef('American:dea57c44'), rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), rdflib.term.URIRef('https://example.org/pizza#American'))\n",
-      "(rdflib.term.URIRef('Mushroom:a8318f66'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'))\n",
-      "(rdflib.term.URIRef('Margherita:5e902c81'), rdflib.term.URIRef('https://example.org/pizza#hasTopping'), rdflib.term.URIRef('https://example.org/pizza#TomatoTopping'))\n"
-     ]
-    }
-   ],
-   "source": [
-    "for k in g:\n",
-    "    print(k)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/test.ipynb
+++ b/examples/test.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,16 +21,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=Nb22d9310eca348d4a45c754e9761f81f (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=N8654802e12c440ba95ab2c745287559a (<class 'rdflib.graph.Graph'>)>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -56,10 +56,10 @@
     {
      "data": {
       "text/plain": [
-       "'PREFIX pizza: <https://example.org/pizza#>\\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\\nSELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\\nWHERE {\\n    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\\n    ?Pizza rdf:type pizza:Pizza .\\n    ?hasTopping_PeperoniSausageTopping rdf:type pizza:PeperoniSausageTopping .\\n}'"
+       "'PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\\nPREFIX pizza: <https://example.org/pizza#>\\nSELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\\nWHERE {\\n    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\\n    ?Pizza rdf:type pizza:Pizza .\\n    ?hasTopping_PeperoniSausageTopping rdf:type pizza:PeperoniSausageTopping .\\n}'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -71,15 +71,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PREFIX pizza: <https://example.org/pizza#>\n",
       "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
+      "PREFIX pizza: <https://example.org/pizza#>\n",
       "SELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\n",
       "WHERE {\n",
       "    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\n",
@@ -95,31 +95,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(rdflib.term.URIRef('American:dea57c44'),)\n",
-      "(rdflib.term.URIRef('AmericanHot:24b1c49f'),)\n",
-      "(rdflib.term.URIRef('Margherita:30a3f96f'),)\n",
-      "(rdflib.term.URIRef('Margherita:5e902c81'),)\n",
-      "(rdflib.term.URIRef('Mushroom:a8318f66'),)\n",
-      "(rdflib.term.URIRef('SpicyPizza:00e5d4e0'),)\n",
-      "(rdflib.term.URIRef('SpicyPizza:0fec2a01'),)\n",
-      "(rdflib.term.URIRef('VegetarianPizza:d152923c'),)\n"
+      "(rdflib.term.URIRef('American:6301092c'), rdflib.term.URIRef('PeperoniSausageTopping:a6dd218a'))\n",
+      "(rdflib.term.URIRef('AmericanHot:c3aee5cd'), rdflib.term.URIRef('PeperoniSausageTopping:a6dd218a'))\n"
      ]
     }
    ],
    "source": [
     "r=g.query(\"\"\"\n",
-    "PREFIX pizza: <https://example.org/pizza#>\n",
     "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
-    "SELECT DISTINCT ?Pizza\n",
+    "PREFIX pizza: <https://example.org/pizza#>\n",
+    "SELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\n",
     "WHERE {\n",
-    "    ?Pizza pizza:hasTopping pizza:MozzarellaTopping .\n",
+    "    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\n",
+    "    ?hasTopping_PeperoniSausageTopping rdf:type pizza:PeperoniSausageTopping .\n",
     "}\n",
     "\"\"\")\n",
     "for a in r:\n",
@@ -216,7 +211,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "rdf",
    "language": "python",
    "name": "python3"
   },
@@ -230,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,

--- a/examples/test.ipynb
+++ b/examples/test.ipynb
@@ -27,7 +27,7 @@
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=Neb8e3e4819864d07a1ff529010a47488 (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=N2f6e51c607bf47e680a800ccdd172c65 (<class 'rdflib.graph.Graph'>)>"
       ]
      },
      "execution_count": 3,
@@ -42,80 +42,132 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['Pizza', 'pizza:hasTopping', 'hasTopping']\n",
-      "['hasTopping', 'hasTopping_PeperoniSausageTopping']\n",
-      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
-      "PREFIX pizza: <https://example.org/pizza#>\n",
-      "SELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\n",
-      "WHERE {\n",
-      "    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\n",
-      "}\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Pizza</th>\n",
+       "      <th>hasTopping_PeperoniSausageTopping</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>American:6301092c</td>\n",
+       "      <td>PeperoniSausageTopping:a6dd218a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AmericanHot:c3aee5cd</td>\n",
+       "      <td>PeperoniSausageTopping:a6dd218a</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  Pizza hasTopping_PeperoniSausageTopping\n",
+       "0     American:6301092c   PeperoniSausageTopping:a6dd218a\n",
+       "1  AmericanHot:c3aee5cd   PeperoniSausageTopping:a6dd218a"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "q = onto.create_query(onto.terms.pizza.Pizza.any, [[onto.terms.pizza.hasTopping, onto.terms.pizza.PeperoniSausageTopping.any],])\n",
-    "print(q)"
+    "q = onto.query(g, onto.terms.pizza.Pizza.any, [[onto.terms.pizza.hasTopping, onto.terms.pizza.PeperoniSausageTopping],])\n",
+    "q"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
-      "PREFIX pizza: <https://example.org/pizza#>\n",
-      "SELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\n",
-      "WHERE {\n",
-      "    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\n",
-      "    ?Pizza rdf:type pizza:Pizza .\n",
-      "    ?hasTopping_PeperoniSausageTopping rdf:type pizza:PeperoniSausageTopping .\n",
-      "}\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>American</th>\n",
+       "      <th>hasTopping_PeperoniSausageTopping</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>American:6301092c</td>\n",
+       "      <td>PeperoniSausageTopping:a6dd218a</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AmericanHot:c3aee5cd</td>\n",
+       "      <td>PeperoniSausageTopping:a6dd218a</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               American hasTopping_PeperoniSausageTopping\n",
+       "0     American:6301092c   PeperoniSausageTopping:a6dd218a\n",
+       "1  AmericanHot:c3aee5cd   PeperoniSausageTopping:a6dd218a"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "print(q)"
+    "q = onto.query(g,onto.terms.pizza.hasTopping, [[onto.terms.pizza.hasTopping, onto.terms.pizza.PeperoniSausageTopping]])\n",
+    "q"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(rdflib.term.URIRef('American:6301092c'), rdflib.term.URIRef('PeperoniSausageTopping:a6dd218a'))\n",
-      "(rdflib.term.URIRef('AmericanHot:c3aee5cd'), rdflib.term.URIRef('PeperoniSausageTopping:a6dd218a'))\n"
-     ]
-    }
-   ],
-   "source": [
-    "r=g.query(\"\"\"\n",
-    "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n",
-    "PREFIX pizza: <https://example.org/pizza#>\n",
-    "SELECT DISTINCT ?Pizza ?hasTopping_PeperoniSausageTopping\n",
-    "WHERE {\n",
-    "    ?Pizza pizza:hasTopping ?hasTopping_PeperoniSausageTopping .\n",
-    "    ?hasTopping_PeperoniSausageTopping rdf:type pizza:PeperoniSausageTopping .\n",
-    "}\n",
-    "\"\"\")\n",
-    "for a in r:\n",
-    "    print(a)"
-   ]
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -11,5 +11,5 @@ def test_network():
 
 def test_owlThing():
     onto = read_ontology()
-    query = (onto.create_query(onto.terms.cmso.AtomicScaleSample,onto.terms.cmso.hasAltName@onto.terms.cmso.CrystalStructure))
+    query = (onto.create_query(onto.terms.cmso.AtomicScaleSample, [[onto.terms.cmso.CrystalStructure, onto.terms.cmso.hasAltName]]))
     assert "CrystalStructure_hasAltNamevalue" in query

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -146,7 +146,7 @@ class Network:
         return query
 
     def create_query(
-        self, source, destinations=None, enforce_types=True, return_list=False
+        self, source, destinations=None, return_list=False
     ):
         # we need to handle source and destination, the primary aim here is to handle source
         if not isinstance(source, list):
@@ -210,7 +210,7 @@ class Network:
         # done, now run the query
         queries = [
             self._create_query(
-                s, destinations=destinations, enforce_types=enforce_types
+                s, destinations=destinations,
             )
             for s in source
         ]
@@ -218,9 +218,9 @@ class Network:
             return queries[0]
         return queries
 
-    def _create_query(self, source, destinations=None, enforce_types=True):
+    def _create_query(self, source, destinations=None):
         """
-        Create a SPARQL query string based on the given source, destinations, condition, and enforce_types.
+        Create a SPARQL query string based on the given source, destinations, condition.
 
         Parameters
         ----------
@@ -231,8 +231,6 @@ class Network:
             node is provided, it will be converted to a list.
             If None, the query will not include any destination nodes, and will simply list objects of the given type.
             None, and `enforced_types` is False, will raise a ValueError.
-        enforce_types : bool, optional
-            Whether to enforce the types of the source and destination nodes in the query. Defaults to True.
 
         Returns
         -------

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -83,7 +83,6 @@ class Network:
             path.append(target.variable_name)
         else:
             path[-1] = target.variable_name
-        print(path)
         #now if target is an object property, we add an extra item to the path to complete it
         return path
 
@@ -349,6 +348,7 @@ class Network:
         return "\n".join(query)
 
     def query(self, kg, source, destinations=None, return_df=True):
+
         query_strings = self.create_query(
             source,
             destinations=destinations,

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -239,9 +239,9 @@ class Network:
             The generated SPARQL query string.
 
         """
-        if destinations is None and not enforce_types:
+        if destinations is None and not source._enforce_type:
             raise ValueError(
-                "If no destinations are provided, enforce_types must be True."
+                "If no destinations are provided, source.any cannot be used!."
             )
 
         if destinations is None:
@@ -348,11 +348,10 @@ class Network:
 
         return "\n".join(query)
 
-    def query(self, kg, source, destinations=None, enforce_types=True, return_df=True):
+    def query(self, kg, source, destinations=None, return_df=True):
         query_strings = self.create_query(
             source,
             destinations=destinations,
-            enforce_types=enforce_types,
             return_list=True,
         )
         res = []

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -304,23 +304,23 @@ class Network:
                     query.append(line_text)
 
         # we enforce types of the source and destination
-        if enforce_types:
-            namespaces_used.append("rdf")
-            if source.node_type == "class":
+        namespaces_used.append("rdf")
+        if source._enforce_type and source.node_type == "class":
+            query.append(
+                "    ?%s rdf:type %s ."
+                % (_strip_name(source.variable_name), source.query_name)
+            )
+
+        for destination in destinations:
+            if destination._enforce_type and destination.node_type == "class":
                 query.append(
                     "    ?%s rdf:type %s ."
-                    % (_strip_name(source.variable_name), source.query_name)
+                    % (
+                        destination.variable_name,
+                        destination.query_name,
+                    )
                 )
 
-            for destination in destinations:
-                if destination.node_type == "class":
-                    query.append(
-                        "    ?%s rdf:type %s ."
-                        % (
-                            destination.variable_name,
-                            destination.query_name,
-                        )
-                    )
         query = self._insert_namespaces(set(namespaces_used)) + query
         # - formulate the condition, given by the `FILTER` command:
         #    - extract the filter text from the term

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -181,10 +181,11 @@ class Network:
                 )
 
             # now check classes; see if anython common classes are not there, if so add.
+            #we just need one common class, these queries will NOT be type fixed
+            common_class = common_classes[0]
             class_names = [c.name for c in classes]
-            for c in common_classes:
-                if c.name not in class_names:
-                    classes.append(c)
+            if common_class.name not in class_names:
+                classes.append(common_class.any)
 
         # now classes are the new source nodes
         # object propertiues are ADDED to the destination nodes

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -192,7 +192,15 @@ class Network:
         if destinations is not None:
             if not isinstance(destinations, list):
                 destinations = [destinations]
-            destinations.extend(object_properties)
+            for object_property in object_properties:
+                already_there = False
+                if object_property in destinations:
+                    already_there = True
+                for d in destinations:
+                    if object_property in d._parents:
+                        already_there = True
+                if not already_there:
+                    destinations.append(object_property)
         else:
             destinations = object_properties
 

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -186,6 +186,19 @@ class Network:
             if common_class.name not in class_names:
                 classes.append(common_class.any)
 
+        #the pplan is to phase out the @ operator, so we look for lists within destinations
+        if destinations is not None:
+            modified_destinations = []
+            for count, destination in enumerate(destinations):
+                if isinstance(destination, (list, tuple)):
+                    last_destination = destination[-1]
+                    for d in destination[:-1]:
+                        last_destination._parents.append(d)
+                    modified_destinations.append(last_destination)
+                else:
+                    modified_destinations.append(destination)
+            destinations = modified_destinations
+
         # now classes are the new source nodes
         # object propertiues are ADDED to the destination nodes
         source = classes
@@ -201,20 +214,9 @@ class Network:
                         already_there = True
                 if not already_there:
                     destinations.append(object_property)
-        else:
+        elif len(object_properties) > 0:
             destinations = object_properties
 
-        #the pplan is to phase out the @ operator, so we look for lists within destinations
-        modified_destinations = []
-        for count, destination in enumerate(destinations):
-            if isinstance(destination, (list, tuple)):
-                last_destination = destination[-1]
-                for d in destination[:-1]:
-                    last_destination._parents.append(d)
-                modified_destinations.append(last_destination)
-            else:
-                modified_destinations.append(destination)
-        destinations = modified_destinations
         # done, now run the query
         queries = [
             self._create_query(

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -121,14 +121,14 @@ class Network:
             # get path for first two terms
             print(f"finding path between {complete_list[0]} and {complete_list[1]}")
             path = self._get_shortest_path(complete_list[0], complete_list[1])
-            for x in range(2, len(complete_list)):
-                temp_source = complete_list[x - 1]
-                temp_dest = complete_list[x]
-                print(f"finding path between {temp_source} and {temp_dest}")
-                temp_path = self._get_shortest_path(temp_source, temp_dest)
-                print(f"temp_path is {temp_path}")
-                path.extend(temp_path[1:])
-                print(f"current path is {path}")
+            #for x in range(2, len(complete_list)):
+            #    temp_source = complete_list[x - 1]
+            #    temp_dest = complete_list[x]
+            #    print(f"finding path between {temp_source} and {temp_dest}")
+            #    temp_path = self._get_shortest_path(temp_source, temp_dest)
+            #    print(f"temp_path is {temp_path}")
+            #    path.extend(temp_path[1:])
+            #    print(f"current path is {path}")
         else:
             path = self._get_shortest_path(source, target)
 

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -115,20 +115,18 @@ class Network:
         if len(target._parents) > 0:
             # this needs a stepped query
             complete_list = [source, *target._parents, target]
-            print(f"target is- {target}")
-            print(f"target parents are- {target._parents}")
-            print(f"complete_list is {complete_list}")
             # get path for first two terms
-            print(f"finding path between {complete_list[0]} and {complete_list[1]}")
             path = self._get_shortest_path(complete_list[0], complete_list[1])
-            #for x in range(2, len(complete_list)):
-            #    temp_source = complete_list[x - 1]
-            #    temp_dest = complete_list[x]
-            #    print(f"finding path between {temp_source} and {temp_dest}")
-            #    temp_path = self._get_shortest_path(temp_source, temp_dest)
-            #    print(f"temp_path is {temp_path}")
-            #    path.extend(temp_path[1:])
-            #    print(f"current path is {path}")
+            for x in range(2, len(complete_list)):
+                temp_source = complete_list[x - 1]
+                temp_dest = complete_list[x]
+                temp_path = self._get_shortest_path(temp_source, temp_dest)
+                if len(temp_path) == 2:
+                    #this means that they are next to each other, so we cannot form a full path
+                    # so we need to add the last item of the previous path
+                    path[-1] = temp_path[-1]
+                else:
+                    path.extend(temp_path[1:])
         else:
             path = self._get_shortest_path(source, target)
 

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -83,7 +83,7 @@ class Network:
             path.append(target.variable_name)
         else:
             path[-1] = target.variable_name
-        #now if target is an object property, we add an extra item to the path to complete it
+        # now if target is an object property, we add an extra item to the path to complete it
         return path
 
     def get_shortest_path(self, source, target, triples=False):
@@ -121,7 +121,7 @@ class Network:
                 temp_dest = complete_list[x]
                 temp_path = self._get_shortest_path(temp_source, temp_dest)
                 if len(temp_path) == 2:
-                    #this means that they are next to each other, so we cannot form a full path
+                    # this means that they are next to each other, so we cannot form a full path
                     # so we need to add the last item of the previous path
                     path[-1] = temp_path[-1]
                 else:
@@ -144,9 +144,7 @@ class Network:
             query.append(f"PREFIX {key}: <{ns[key]}>")
         return query
 
-    def create_query(
-        self, source, destinations=None, return_list=False
-    ):
+    def create_query(self, source, destinations=None, return_list=False):
         # we need to handle source and destination, the primary aim here is to handle source
         if not isinstance(source, list):
             source = [source]
@@ -180,13 +178,13 @@ class Network:
                 )
 
             # now check classes; see if anython common classes are not there, if so add.
-            #we just need one common class, these queries will NOT be type fixed
+            # we just need one common class, these queries will NOT be type fixed
             common_class = common_classes[0]
             class_names = [c.name for c in classes]
             if common_class.name not in class_names:
                 classes.append(common_class.any)
 
-        #the pplan is to phase out the @ operator, so we look for lists within destinations
+        # the pplan is to phase out the @ operator, so we look for lists within destinations
         if destinations is not None:
             modified_destinations = []
             for count, destination in enumerate(destinations):
@@ -220,7 +218,8 @@ class Network:
         # done, now run the query
         queries = [
             self._create_query(
-                s, destinations=destinations,
+                s,
+                destinations=destinations,
             )
             for s in source
         ]

--- a/tools4rdf/network/term.py
+++ b/tools4rdf/network/term.py
@@ -109,6 +109,7 @@ class OntoTerm:
         # these are accumulated when using the & or || operators
         self._condition_parents = []
         self.target = target
+        self._enforce_type = True
 
     @property
     def URIRef(self):
@@ -300,6 +301,13 @@ class OntoTerm:
             return self.name_without_prefix + "value"
         return self.name_without_prefix
 
+    @property
+    def any(self):
+        #this indicates that type enforcing is not needed
+        item = copy.deepcopy(self)
+        item._enforce_type = False
+        return item
+    
     def toPython(self):
         return self.uri
 
@@ -430,6 +438,7 @@ class OntoTerm:
         item = copy.deepcopy(self)
         item._parents.append(copy.deepcopy(term))
         return item
+    
 
     def refresh_condition(self):
         self._condition = None

--- a/tools4rdf/network/term.py
+++ b/tools4rdf/network/term.py
@@ -7,6 +7,7 @@ import numbers
 import copy
 import warnings
 
+
 def _get_namespace_and_name(uri):
     uri_split = uri.split("#")
     if len(uri_split) > 1:
@@ -257,7 +258,7 @@ class OntoTerm:
         """
         if self.node_type == "data_property":
             return self.name + "value"
-        #elif self.node_type == "object_property":
+        # elif self.node_type == "object_property":
         #    if len(self.range) > 0:
         #        # this has a domain
         #        return self.range[0]
@@ -303,18 +304,18 @@ class OntoTerm:
 
     @property
     def any(self):
-        #this indicates that type enforcing is not needed
+        # this indicates that type enforcing is not needed
         item = copy.deepcopy(self)
         item._enforce_type = False
         return item
-    
+
     def toPython(self):
         return self.uri
 
     def __repr__(self):
-        #if self.description is not None:
+        # if self.description is not None:
         #    return str(self.name + "\n" + self.description)
-        #else:
+        # else:
         return str(self.name)
 
     def _clean_datatype(self, r):
@@ -359,7 +360,7 @@ class OntoTerm:
             return item
         else:
             return self.name == val.name
-        
+
     def __lt__(self, val):
         self._is_number(val)
         self._is_data_node()
@@ -433,14 +434,13 @@ class OntoTerm:
         self.__or__(term)
 
     def __matmul__(self, term):
-        #we will phase out this operator soon
+        # we will phase out this operator soon
         warnings.warn(
             "The @ operator is deprecated and will be removed in future versions. termA@termB should be [termA, termB] instead.",
         )
         item = copy.deepcopy(self)
         item._parents.append(copy.deepcopy(term))
         return item
-    
 
     def refresh_condition(self):
         self._condition = None

--- a/tools4rdf/network/term.py
+++ b/tools4rdf/network/term.py
@@ -353,11 +353,13 @@ class OntoTerm:
         """
         # print("eq")
         # print(f'lhs {self} rhs {val}')
-        self._is_data_node()
-        item = copy.deepcopy(self)
-        item._condition = item._create_condition_string("=", val)
-        return item
-
+        if self.node_type == "data_property":
+            item = copy.deepcopy(self)
+            item._condition = item._create_condition_string("=", val)
+            return item
+        else:
+            return self.name == val.name
+        
     def __lt__(self, val):
         self._is_number(val)
         self._is_data_node()

--- a/tools4rdf/network/term.py
+++ b/tools4rdf/network/term.py
@@ -256,10 +256,10 @@ class OntoTerm:
         """
         if self.node_type == "data_property":
             return self.name + "value"
-        elif self.node_type == "object_property":
-            if len(self.range) > 0:
-                # this has a domain
-                return self.range[0]
+        #elif self.node_type == "object_property":
+        #    if len(self.range) > 0:
+        #        # this has a domain
+        #        return self.range[0]
         return self.name
 
     @property
@@ -304,10 +304,10 @@ class OntoTerm:
         return self.uri
 
     def __repr__(self):
-        if self.description is not None:
-            return str(self.name + "\n" + self.description)
-        else:
-            return str(self.name)
+        #if self.description is not None:
+        #    return str(self.name + "\n" + self.description)
+        #else:
+        return str(self.name)
 
     def _clean_datatype(self, r):
         if r == "str":

--- a/tools4rdf/network/term.py
+++ b/tools4rdf/network/term.py
@@ -5,7 +5,7 @@ https://docs.python.org/3/library/operator.html
 from rdflib import URIRef
 import numbers
 import copy
-
+import warnings
 
 def _get_namespace_and_name(uri):
     uri_split = uri.split("#")
@@ -423,8 +423,10 @@ class OntoTerm:
         self.__or__(term)
 
     def __matmul__(self, term):
-        # print("matmul")
-        # print(f'lhs {self} rhs {term}')
+        #we will phase out this operator soon
+        warnings.warn(
+            "The @ operator is deprecated and will be removed in future versions. termA@termB should be [termA, termB] instead.",
+        )
         item = copy.deepcopy(self)
         item._parents.append(copy.deepcopy(term))
         return item


### PR DESCRIPTION
This pull request includes several changes to the `examples` and `tools4rdf/network` files, focusing on updating notebook configurations, adding new data, and modifying network query methods. The most important changes include updates to the SPARQL queries, adjustments to the pizza knowledge graph data, and improvements in the handling of object properties and type enforcement in the network module.


SPARQL query improvements:

* [`tools4rdf/network/network.py`](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dR82-R86): Enhanced the `_get_shortest_path` and `get_shortest_path` methods to handle object properties correctly and ensure complete paths. [[1]](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dR82-R86) [[2]](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dR123-R127)
* [`tools4rdf/network/network.py`](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dL138-R147): Refactored the `create_query` and `_create_query` methods to simplify type enforcement and handle lists within destinations. [[1]](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dL138-R147) [[2]](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dR181-R232) [[3]](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dL213-R252) [[4]](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dL286-R330) [[5]](diffhunk://#diff-c65d10d889afdc00df14012c42880d7e12ae45c651c39d9837787a701d1a6c0dL331-L335)

Type enforcement and operator deprecation:

* [`tools4rdf/network/term.py`](diffhunk://#diff-1d8ddb70592f9cb33162864be550aebc150c6c1a9d87a08e388cf4db4b8ab78fR8): Introduced the `_enforce_type` attribute and the `any` property to control type enforcement in queries. Deprecated the `@` operator in favor of using lists for term combinations. [[1]](diffhunk://#diff-1d8ddb70592f9cb33162864be550aebc150c6c1a9d87a08e388cf4db4b8ab78fR8) [[2]](diffhunk://#diff-1d8ddb70592f9cb33162864be550aebc150c6c1a9d87a08e388cf4db4b8ab78fR113) [[3]](diffhunk://#diff-1d8ddb70592f9cb33162864be550aebc150c6c1a9d87a08e388cf4db4b8ab78fL259-R264) [[4]](diffhunk://#diff-1d8ddb70592f9cb33162864be550aebc150c6c1a9d87a08e388cf4db4b8ab78fR305-R318) [[5]](diffhunk://#diff-1d8ddb70592f9cb33162864be550aebc150c6c1a9d87a08e388cf4db4b8ab78fL348-R362) [[6]](diffhunk://#diff-1d8ddb70592f9cb33162864be550aebc150c6c1a9d87a08e388cf4db4b8ab78fL426-R440)