### PR TITLE
bug fix to read prov

### DIFF
--- a/tools4rdf/network/parser.py
+++ b/tools4rdf/network/parser.py
@@ -344,7 +344,7 @@ class OntoParser:
             self.attributes["class"][term.name] = term
             parents = list(self.graph.objects(cls, RDF.type))
             for parent in parents:
-                if parent != OWL.NamedIndividual:
+                if parent not in [OWL.NamedIndividual, OWL.Class]:
                     self.attributes["class"][
                         strip_name(parent.toPython())
                     ].named_individuals.append(term.name)


### PR DESCRIPTION
This pull request includes a change to the `tools4rdf/network/parser.py` file to improve the handling of RDF types.

* [`tools4rdf/network/parser.py`](diffhunk://#diff-64e602b978869249cd960cb3ea0cbcc3aacdacf3a37f5f008599cf7c65f6a5b9L347-R347): Updated the `parse_named_individuals` method to include `OWL.Class` in the list of RDF types to be excluded when processing parent terms.