### PR TITLE
Warn instead of fail

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = False
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,4 +19,4 @@ authors:
 license: "MIT"
 repository-code: https://github.com/codo/tools4RDF
 type: software
-version: 0.3.0
+version: 0.3.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as readme_file:
 
 setup(
     name='tools4rdf',
-    version='0.3.0',
+    version='0.3.1',
     author='Abril Azocar Guzman, Sarath Menon',
     author_email='sarath.menon@pyscal.org',
     description='python tool for working with ontologies and data models',


### PR DESCRIPTION
This pull request includes a version update for the `tools4rdf` package and introduces a warning mechanism for missing attributes in the `extract_subproperties` method. The most important changes are summarized below:

### Code Enhancements:
* Added the `warnings` module to `tools4rdf/network/parser.py` to handle runtime warnings.
* Modified the `extract_subproperties` method in `tools4rdf/network/parser.py` to include a warning if a superproperty is not found in the attributes dictionary. This ensures better debugging and error tracing for ontology parsing.
