### PR TITLE
Add limit

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.3.3
 commit = True
 tag = False
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,4 +19,4 @@ authors:
 license: "MIT"
 repository-code: https://github.com/codo/tools4RDF
 type: software
-version: 0.3.2
+version: 0.3.3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as readme_file:
 
 setup(
     name='tools4rdf',
-    version='0.3.2',
+    version='0.3.3',
     author='Abril Azocar Guzman, Sarath Menon',
     author_email='sarath.menon@pyscal.org',
     description='python tool for working with ontologies and data models',

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -308,7 +308,9 @@ class Network:
                 return True
         return False
 
-    def create_query(self, source, destinations=None, return_list=False, num_paths=1):
+    def create_query(
+        self, source, destinations=None, return_list=False, num_paths=1, limit=None
+    ):
         """
         Creates a query based on the given source and destination nodes.
 
@@ -325,6 +327,8 @@ class Network:
             if only one query is generated. Default is False.
         num_paths : int, optional
             The number of paths to consider in the query. Default is 1.
+        limit : int, optional
+            The maximum number of results to return. Default is None (no limit).
 
         Raises
         ------
@@ -430,7 +434,9 @@ class Network:
         # done, now run the query
         queries = []
         for s in classes:
-            qx = self._create_query(s, destinations=destinations, num_paths=num_paths)
+            qx = self._create_query(
+                s, destinations=destinations, num_paths=num_paths, limit=limit
+            )
             queries.extend(
                 qx,
             )
@@ -728,7 +734,24 @@ class Network:
             destination.refresh()
         return query
 
-    def _create_query(self, source, destinations=None, num_paths=1):
+    def _add_limit(self, limit=None):
+        """
+        Adds a LIMIT clause to a SPARQL query if a limit is specified.
+
+        Parameters
+        ----------
+        limit : int or None
+            The maximum number of results to return. If None, no LIMIT clause is added.
+
+        Returns
+        -------
+        str
+            The modified SPARQL query with the LIMIT clause added if applicable.
+        """
+        if limit is not None:
+            return f"LIMIT {limit}"
+
+    def _create_query(self, source, destinations=None, num_paths=1, limit=None):
         """
         Creates SPARQL queries based on the given source, destinations, and number of paths.
 
@@ -745,6 +768,8 @@ class Network:
             A list of destination nodes for the query. If not provided, defaults to None.
         num_paths : int, optional
             The number of paths to include in the query. Defaults to 1.
+        limit : int, optional
+            The maximum number of results to return. Default is None (no limit).
 
         Returns
         -------
@@ -801,6 +826,7 @@ class Network:
                 + query_footer_source_types
                 + query_footer_dest_types
                 + query_filter
+                + self._add_limit(limit)
             )
             created_queries.append("\n".join(query))
         return created_queries

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -750,6 +750,7 @@ class Network:
         """
         if limit is not None:
             return f"LIMIT {limit}"
+        return ""
 
     def _create_query(self, source, destinations=None, num_paths=1, limit=None):
         """

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -831,7 +831,9 @@ class Network:
             created_queries.append("\n".join(query))
         return created_queries
 
-    def query(self, kg, source, destinations=None, return_df=True, num_paths=1):
+    def query(
+        self, kg, source, destinations=None, return_df=True, num_paths=1, limit=None
+    ):
         """
         Executes queries on a knowledge graph (KG) to retrieve data from a SPARQL query.
 
@@ -847,6 +849,8 @@ class Network:
             If True, the results will be returned as a concatenated pandas DataFrame. Otherwise, results will be returned as a list.
         num_paths : int, default=1
             The number of paths to retrieve for each query.
+        limit : int, optional
+            The maximum number of results to return. If None, no limit is applied.
 
         Returns
         -------
@@ -861,6 +865,7 @@ class Network:
             destinations=destinations,
             return_list=True,
             num_paths=num_paths,
+            limit=limit,
         )
         res = []
         for query_string in query_strings:

--- a/tools4rdf/network/network.py
+++ b/tools4rdf/network/network.py
@@ -749,8 +749,8 @@ class Network:
             The modified SPARQL query with the LIMIT clause added if applicable.
         """
         if limit is not None:
-            return f"LIMIT {limit}"
-        return ""
+            return [f"LIMIT {limit}"]
+        return []
 
     def _create_query(self, source, destinations=None, num_paths=1, limit=None):
         """


### PR DESCRIPTION
This pull request introduces a version update for the `tools4rdf` package and adds a new feature to limit query results in the `network.py` module. The most important changes include updating the version across configuration and metadata files and extending query-related methods to support a `limit` parameter for controlling the maximum number of results.
